### PR TITLE
Typing error in FilterSingletonEvent

### DIFF
--- a/Event/FilterSingletonEvent.php
+++ b/Event/FilterSingletonEvent.php
@@ -61,7 +61,7 @@ class FilterSingletonEvent extends Event
     /**
      * Set filters.
      *
-     * @param string $filters
+     * @param array $filters
      *
      * @return self
      */


### PR DESCRIPTION
- Modifies the typing of the $filters parameter on the setFilters
method of FilterSingletonEven, from string to array, to comply
with declaration