### PR TITLE
fix: modified SingletonCRUDController to use new sonata admin version

### DIFF
--- a/Controller/Sonata/SingletonCRUDController.php
+++ b/Controller/Sonata/SingletonCRUDController.php
@@ -2,7 +2,6 @@
 
 namespace Umanit\DoctrineSingletonBundle\Controller\Sonata;
 
-use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Sonata\AdminBundle\Controller\CRUDController;
 use Umanit\MultiSiteBundle\Utils\SiteAccessesManager;
@@ -17,16 +16,27 @@ class SingletonCRUDController extends CRUDController
      */
     public function listAction()
     {
-        /** @var Paginator $resultList */
+        /** @var Paginator|array $resultList */
         $resultList = $this->admin->getDatagrid()->getResults();
 
-        if ($resultList->count() > 1) {
-            return parent::listAction();
-        }
+        if ($resultList instanceof Paginator) {
+            if ($resultList->count() > 1) {
+                return parent::listAction();
+            }
 
-        if (1 === $resultList->count()) {
-            $result = $resultList->getIterator()->current();
-            return $this->redirect($this->admin->generateObjectUrl('edit', $result));
+            if (1 === $resultList->count()) {
+                $result = $resultList->getIterator()->current();
+                return $this->redirect($this->admin->generateObjectUrl('edit', $result));
+            }
+        } else {
+            $result = $this->admin->getDatagrid()->getResults();
+            if (count($result) > 1) {
+                return parent::listAction();
+            }
+
+            if (count($result) === 1) {
+                return $this->redirect($this->admin->generateObjectUrl('edit', $result[0]));
+            }
         }
 
         return $this->redirect($this->admin->generateUrl('create'));

--- a/Controller/Sonata/SingletonCRUDController.php
+++ b/Controller/Sonata/SingletonCRUDController.php
@@ -3,6 +3,7 @@
 namespace Umanit\DoctrineSingletonBundle\Controller\Sonata;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\Pagination\Paginator;
 use Sonata\AdminBundle\Controller\CRUDController;
 use Umanit\MultiSiteBundle\Utils\SiteAccessesManager;
 
@@ -16,13 +17,16 @@ class SingletonCRUDController extends CRUDController
      */
     public function listAction()
     {
-        $result = $this->admin->getDatagrid()->getResults();
-        if (count($result) > 1) {
+        /** @var Paginator $resultList */
+        $resultList = $this->admin->getDatagrid()->getResults();
+
+        if ($resultList->count() > 1) {
             return parent::listAction();
         }
 
-        if (count($result) === 1) {
-            return $this->redirect($this->admin->generateObjectUrl('edit', $result[0]));
+        if (1 === $resultList->count()) {
+            $result = $resultList->getIterator()->current();
+            return $this->redirect($this->admin->generateObjectUrl('edit', $result));
         }
 
         return $this->redirect($this->admin->generateUrl('create'));


### PR DESCRIPTION
Sonata\AdminBundle\Datagrid\DatagridInterface::getResults now returns object Doctrine\ORM\Tools\Pagination\Paginator instead of array